### PR TITLE
Fix/base58check for colored address

### DIFF
--- a/src/address.js
+++ b/src/address.js
@@ -10,11 +10,21 @@ const typeforce = require('typeforce');
 function fromBase58Check(address) {
   const payload = bs58check.decode(address);
   // TODO: 4.0.0, move to "toOutputScript"
-  if (payload.length < 21) throw new TypeError(address + ' is too short');
-  if (payload.length > 21) throw new TypeError(address + ' is too long');
+  if (payload.length < 21)
+    throw new TypeError(`${address} is too short(${payload.length})`);
+  if (payload.length > 54)
+    throw new TypeError(`${address} is too long(${payload.length})`);
   const version = payload.readUInt8(0);
-  const hash = payload.slice(1);
-  return { version, hash };
+  if (payload.length > 21) {
+    // Colored
+    const colorId = payload.slice(1, 34);
+    const hash = payload.slice(34);
+    return { version, colorId, hash };
+  } else {
+    // Uncolored
+    const hash = payload.slice(1);
+    return { version, hash };
+  }
 }
 exports.fromBase58Check = fromBase58Check;
 function fromBech32(address) {
@@ -27,11 +37,16 @@ function fromBech32(address) {
   };
 }
 exports.fromBech32 = fromBech32;
-function toBase58Check(hash, version) {
+function toBase58Check(hash, version, colorId) {
   typeforce(types.tuple(types.Hash160bit, types.UInt8), arguments);
-  const payload = Buffer.allocUnsafe(21);
+  const payload = colorId ? Buffer.allocUnsafe(54) : Buffer.allocUnsafe(21);
   payload.writeUInt8(version, 0);
-  hash.copy(payload, 1);
+  if (colorId) {
+    colorId.copy(payload, 1);
+    hash.copy(payload, 34);
+  } else {
+    hash.copy(payload, 1);
+  }
   return bs58check.encode(payload);
 }
 exports.toBase58Check = toBase58Check;
@@ -62,9 +77,15 @@ function toOutputScript(address, network) {
     if (decodeBase58.version === network.scriptHash)
       return payments.p2sh({ hash: decodeBase58.hash }).output;
     if (decodeBase58.version === network.coloredPubKeyHash)
-      return payments.cp2pkh({ hash: decodeBase58.hash }).output;
+      return payments.cp2pkh({
+        hash: decodeBase58.hash,
+        colorId: decodeBase58.colorId,
+      }).output;
     if (decodeBase58.version === network.coloredScriptHash)
-      return payments.cp2sh({ hash: decodeBase58.hash }).output;
+      return payments.cp2sh({
+        hash: decodeBase58.hash,
+        colorId: decodeBase58.colorId,
+      }).output;
   } else {
     try {
       decodeBech32 = fromBech32(address);

--- a/src/address.js
+++ b/src/address.js
@@ -19,10 +19,16 @@ function fromBase58Check(address) {
     // Colored
     const colorId = payload.slice(1, 34);
     const hash = payload.slice(34);
+    if (hash.length !== 20) {
+      throw new TypeError(`Invalid hash(${hash})`);
+    }
     return { version, colorId, hash };
   } else {
     // Uncolored
     const hash = payload.slice(1);
+    if (hash.length !== 20) {
+      throw new TypeError(`Invalid hash(${hash})`);
+    }
     return { version, hash };
   }
 }

--- a/src/payments/util.js
+++ b/src/payments/util.js
@@ -24,7 +24,7 @@ function fromOutputScript(output, network) {
     return payments.cp2pkh({ output, network });
   } catch (e) {}
   try {
-    return payments.cp2pkh({ output, network });
+    return payments.cp2sh({ output, network });
   } catch (e) {}
   throw new Error(bscript.toASM(output) + ' is not standard script');
 }

--- a/test/address.spec.ts
+++ b/test/address.spec.ts
@@ -16,6 +16,9 @@ describe('address', () => {
 
         assert.strictEqual(decode.version, f.version);
         assert.strictEqual(decode.hash.toString('hex'), f.hash);
+        if (f.colorId) {
+          assert.strictEqual(decode.colorId!.toString('hex'), f.colorId);
+        }
       });
     });
 
@@ -76,9 +79,11 @@ describe('address', () => {
       if (!f.base58check) return;
 
       it('encodes ' + f.hash + ' (' + f.network + ')', () => {
+        const colorId = f.colorId ? Buffer.from(f.colorId, 'hex') : undefined;
         const address = baddress.toBase58Check(
           Buffer.from(f.hash, 'hex'),
           f.version,
+          colorId,
         );
 
         assert.strictEqual(address, f.base58check);

--- a/test/bitcoin.core.spec.ts
+++ b/test/bitcoin.core.spec.ts
@@ -67,8 +67,12 @@ describe('Bitcoin-core', () => {
     const allowedNetworks = [
       bitcoin.networks.prod.pubKeyHash,
       bitcoin.networks.prod.scriptHash,
+      bitcoin.networks.prod.coloredPubKeyHash,
+      bitcoin.networks.prod.coloredScriptHash,
       bitcoin.networks.dev.pubKeyHash,
       bitcoin.networks.dev.scriptHash,
+      bitcoin.networks.dev.coloredPubKeyHash,
+      bitcoin.networks.dev.coloredScriptHash,
     ];
 
     base58KeysInvalid.forEach(f => {
@@ -77,13 +81,12 @@ describe('Bitcoin-core', () => {
       it('throws on ' + strng, () => {
         assert.throws(() => {
           const address = bitcoin.address.fromBase58Check(strng);
-
           assert.notStrictEqual(
             allowedNetworks.indexOf(address.version),
             -1,
             'Invalid network',
           );
-        }, /(Invalid (checksum|network))|(too (short|long))/);
+        }, /(Invalid (checksum|network|hash|token type))|(too (short|long))/);
       });
     });
   });

--- a/test/fixtures/address.json
+++ b/test/fixtures/address.json
@@ -15,6 +15,22 @@
       "script": "OP_HASH160 cd7b44d0b03f2d026d1e586d7ae18903b0d385f6 OP_EQUAL"
     },
     {
+      "network": "prod",
+      "version": 1,
+      "colorId": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46",
+      "hash": "168b992bcfc44050310b3a94bd0771136d0b28d1",
+      "base58check": "w26x2EaheVBsceNf9RufpmmZ1i1qLBux1UMKMs16dkcZxNzBTgnA23SYR9oJKDRMQQUdZawBnneKjP",
+      "script": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46 OP_COLOR OP_DUP OP_HASH160 168b992bcfc44050310b3a94bd0771136d0b28d1 OP_EQUALVERIFY OP_CHECKSIG"
+    },
+    {
+      "network": "prod",
+      "version": 6,
+      "colorId": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46",
+      "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
+      "base58check": "4a28F5ZehQNaMsSCEzBGQSKjVx2Wz2c4s32joimPciFTLzft1F9nPHMTeHMRQ6fzf9is4AcFxQr5Vye",
+      "script": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46 OP_COLOR OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL"
+    },
+    {
       "network": "dev",
       "version": 111,
       "hash": "751e76e8199196d454941c45d1b3a323f1433bd6",
@@ -48,6 +64,22 @@
       "bech32": "tb1qqqqqp399et2xygdj5xreqhjjvcmzhxw4aywxecjdzew6hylgvsesrxh6hy",
       "data": "000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433",
       "script": "OP_0 000000c4a5cad46221b2a187905e5266362b99d5e91c6ce24d165dab93e86433"
+    },
+    {
+      "network": "dev",
+      "version": 112,
+      "colorId": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46",
+      "hash": "168b992bcfc44050310b3a94bd0771136d0b28d1",
+      "base58check": "22VdQ5VjWcF9zgsnPQodFBS1PBQPaAQEXSofkyMv2D9zV1MGR6XAoYysVri1WbMg5zBBR6qCvcU9yKfY",
+      "script": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46 OP_COLOR OP_DUP OP_HASH160 168b992bcfc44050310b3a94bd0771136d0b28d1 OP_EQUALVERIFY OP_CHECKSIG"
+    },
+    {
+      "network": "dev",
+      "version": 197,
+      "colorId": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46",
+      "hash": "9f840a5fc02407ef0ad499c2ec0eb0b942fb0086",
+      "base58check": "2oLdn5UKgY7DayDDLL6LKfrNnHKp7iFK8zGAMHVGd2USnCxmpNXbY4o4ML7h89Xojd7Lus68qTQVeTn8",
+      "script": "c3ec2fd806701a3f55808cbec3922c38dafaa3070c48c803e9043ee3642c660b46 OP_COLOR OP_HASH160 9f840a5fc02407ef0ad499c2ec0eb0b942fb0086 OP_EQUAL"
     }
   ],
   "bech32": [
@@ -99,7 +131,7 @@
         "exception": "is too short"
       },
       {
-        "address": "j9ywUkWg2fTQrouxxh5rSZhRvrjMkEUfuiKe",
+        "address": "Gkjxy997PLAEF7cCcjNJzSmgamshLi5n3qxfwDLvpd4oHGDH5FyuTHvY4ERWaykpZYqDtvzwntyjfiN5",
         "exception": "is too long"
       }
     ],

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -11,6 +11,7 @@ const typeforce = require('typeforce');
 export interface Base58CheckResult {
   hash: Buffer;
   version: number;
+  colorId?: Buffer;
 }
 
 export interface Bech32Result {
@@ -20,16 +21,23 @@ export interface Bech32Result {
 }
 
 export function fromBase58Check(address: string): Base58CheckResult {
-  const payload = bs58check.decode(address);
+  const payload: Buffer = bs58check.decode(address);
 
   // TODO: 4.0.0, move to "toOutputScript"
-  if (payload.length < 21) throw new TypeError(address + ' is too short');
-  if (payload.length > 21) throw new TypeError(address + ' is too long');
+  if (payload.length < 21) throw new TypeError(`${address} is too short(${payload.length})`);
+  if (payload.length > 54) throw new TypeError(`${address} is too long(${payload.length})`);
 
   const version = payload.readUInt8(0);
-  const hash = payload.slice(1);
-
-  return { version, hash };
+  if (payload.length > 21) {
+    // Colored
+    const colorId = payload.slice(1, 34);
+    const hash = payload.slice(34);
+    return { version, colorId, hash };
+  } else {
+    // Uncolored
+    const hash = payload.slice(1);
+    return { version, hash };
+  }
 }
 
 export function fromBech32(address: string): Bech32Result {
@@ -43,13 +51,18 @@ export function fromBech32(address: string): Bech32Result {
   };
 }
 
-export function toBase58Check(hash: Buffer, version: number): string {
+export function toBase58Check(hash: Buffer, version: number, colorId?: Buffer): string {
   typeforce(types.tuple(types.Hash160bit, types.UInt8), arguments);
 
-  const payload = Buffer.allocUnsafe(21);
+  const payload = colorId ? Buffer.allocUnsafe(54) : Buffer.allocUnsafe(21);
   payload.writeUInt8(version, 0);
-  hash.copy(payload, 1);
-
+  if (colorId) {
+    colorId.copy(payload, 1);
+    hash.copy(payload, 34);
+  } else {
+    hash.copy(payload, 1);
+  }
+  
   return bs58check.encode(payload);
 }
 
@@ -87,9 +100,9 @@ export function toOutputScript(address: string, network?: Network): Buffer {
     if (decodeBase58.version === network.scriptHash)
       return payments.p2sh({ hash: decodeBase58.hash }).output as Buffer;
     if (decodeBase58.version === network.coloredPubKeyHash)
-      return payments.cp2pkh({ hash: decodeBase58.hash }).output as Buffer;
+      return payments.cp2pkh({ hash: decodeBase58.hash, colorId: decodeBase58.colorId }).output as Buffer;
     if (decodeBase58.version === network.coloredScriptHash)
-      return payments.cp2sh({ hash: decodeBase58.hash }).output as Buffer;
+      return payments.cp2sh({ hash: decodeBase58.hash, colorId: decodeBase58.colorId }).output as Buffer;
   } else {
     try {
       decodeBech32 = fromBech32(address);

--- a/ts_src/address.ts
+++ b/ts_src/address.ts
@@ -20,30 +20,32 @@ export interface Bech32Result {
   data: Buffer;
 }
 
+const PUBKEY_HASH_LENGTH = 20;
+const COLOR_ID_LENGTH = 33;
+const UNCOLORED_LENGTH = 1 + PUBKEY_HASH_LENGTH; // 21
+const COLORED_LENGTH = 1 + PUBKEY_HASH_LENGTH + COLOR_ID_LENGTH; // 54
+
 export function fromBase58Check(address: string): Base58CheckResult {
   const payload: Buffer = bs58check.decode(address);
 
   // TODO: 4.0.0, move to "toOutputScript"
-  if (payload.length < 21)
+  if (payload.length < UNCOLORED_LENGTH)
     throw new TypeError(`${address} is too short(${payload.length})`);
-  if (payload.length > 54)
+  if (payload.length > COLORED_LENGTH)
     throw new TypeError(`${address} is too long(${payload.length})`);
 
   const version = payload.readUInt8(0);
-  if (payload.length > 21) {
+  if (payload.length > UNCOLORED_LENGTH) {
     // Colored
-    const colorId = payload.slice(1, 34);
-    const hash = payload.slice(34);
-    if (hash.length !== 20) {
+    const colorId = payload.slice(1, 1 + COLOR_ID_LENGTH);
+    const hash = payload.slice(1 + COLOR_ID_LENGTH);
+    if (hash.length !== PUBKEY_HASH_LENGTH) {
       throw new TypeError(`Invalid hash(${hash})`);
     }
     return { version, colorId, hash };
   } else {
     // Uncolored
     const hash = payload.slice(1);
-    if (hash.length !== 20) {
-      throw new TypeError(`Invalid hash(${hash})`);
-    }
     return { version, hash };
   }
 }
@@ -66,11 +68,13 @@ export function toBase58Check(
 ): string {
   typeforce(types.tuple(types.Hash160bit, types.UInt8), arguments);
 
-  const payload = colorId ? Buffer.allocUnsafe(54) : Buffer.allocUnsafe(21);
+  const payload = colorId
+    ? Buffer.allocUnsafe(COLORED_LENGTH)
+    : Buffer.allocUnsafe(UNCOLORED_LENGTH);
   payload.writeUInt8(version, 0);
   if (colorId) {
     colorId.copy(payload, 1);
-    hash.copy(payload, 34);
+    hash.copy(payload, 1 + COLOR_ID_LENGTH);
   } else {
     hash.copy(payload, 1);
   }

--- a/ts_src/payments/util.ts
+++ b/ts_src/payments/util.ts
@@ -27,7 +27,7 @@ export function fromOutputScript(output: Buffer, network?: Network): Payment {
     return payments.cp2pkh({ output, network });
   } catch (e) {}
   try {
-    return payments.cp2pkh({ output, network });
+    return payments.cp2sh({ output, network });
   } catch (e) {}
 
   throw new Error(bscript.toASM(output) + ' is not standard script');

--- a/types/address.d.ts
+++ b/types/address.d.ts
@@ -2,6 +2,7 @@ import { Network } from './networks';
 export interface Base58CheckResult {
     hash: Buffer;
     version: number;
+    colorId?: Buffer;
 }
 export interface Bech32Result {
     version: number;
@@ -10,7 +11,7 @@ export interface Bech32Result {
 }
 export declare function fromBase58Check(address: string): Base58CheckResult;
 export declare function fromBech32(address: string): Bech32Result;
-export declare function toBase58Check(hash: Buffer, version: number): string;
+export declare function toBase58Check(hash: Buffer, version: number, colorId?: Buffer): string;
 export declare function toBech32(data: Buffer, version: number, prefix: string): string;
 export declare function fromOutputScript(output: Buffer, network?: Network): string;
 export declare function toOutputScript(address: string, network?: Network): Buffer;


### PR DESCRIPTION
The function `fromBase58Check` in address.ts does not support colored coin address defined in https://github.com/chaintope/tapyrus-core/blob/master/doc/tapyrus/colored_coin.md.

This PR adds the feature to convert colored addresses to their scripts.
